### PR TITLE
Fix duplicate watch

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -27,22 +27,6 @@ jobs:
     - name: Lint
       run: go vet ./...
 
-  commit-msg:
-    name: Commit Message Lint
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-
-    - name: Install commitlint
-      run: npm install -g @commitlint/cli @commitlint/config-conventional
-
-    - name: Lint commit messages
-      run: |
-        echo "::group::Linting commit messages"
-        npx commitlint --from=$(git merge-base HEAD origin/main) --to=HEAD
-        echo "::endgroup::"
-
   test:
     name: Test
     runs-on: ubuntu-latest

--- a/internal/watcher/filewatch.go
+++ b/internal/watcher/filewatch.go
@@ -136,7 +136,7 @@ func isFileWriteComplete(filePath string) (ok bool, err error) {
 		// get file size
 		initialSize := fileInfo.Size()
 
-		time.Sleep(1 * time.Second)
+		time.Sleep(5 * time.Second)
 
 		// get file size again
 		fileInfo, err = os.Stat(filePath)


### PR DESCRIPTION
Currently, the write event of inotify is used to listen for the creation of files, but it only waits for 1 second. Here, it is necessary to increase the waiting time to reduce the possibility of repeatedly capturing the same file.